### PR TITLE
Update output with offsets

### DIFF
--- a/dumpjpg.py
+++ b/dumpjpg.py
@@ -1,55 +1,76 @@
 #! /usr/bin/env python3
-
-# dumpjpg.py  14/12/2022  D.J.Whale
+##
+import os
 
 FILENAME = "photo13.png"
 
 FLAGS = {
-    "D8": "SOI: Start of image",                # no payload
-    "C0": "SOF0: Start of frame",               # variable size
-    "C2": "SOF2: Start of frame",               # variable size
-    "C4": "DHT: define huffman tables",         # variable size
-    "D9": "EOI: End Of Image",                  # no payload
+    "D8": "SOI: Start of Image",                # standalone, no payload
+    "C0": "SOF0: Start of Frame",               # variable size
+    "C2": "SOF2: Start of Frame",               # variable size
+    "C4": "DHT: Define Huffman Table(s)",       # variable size
+    "D9": "EOI: End of Image",                  # stand alone, no payload
     "DB": "DQT: Define Quantization Table(s)",  # variable size
     "DD": "DRI: Define Restart Interval",       # 4 bytes
-    "DA": "SOS: Start Of Scan",                 # variable size
+    "DA": "SOS: Start of Scan",                 # variable size
     "D*": "RSTn: Restart",                      # no data, n=0..7
     "E*": "APPn: Application specific",         # variable size n=0..F
     "FE": "COM: Comment",                       # variable size
 }
 
+# invariant: offset of last byte read; -1 means no bytes read
+offset = -1
+
 def get_byte(f) -> int:
     b = f.read(1)
+    global offset
+    offset += 1
     if len(b) == 0: exit(0)  # EOF
     b = b[0]
     return b
 
 def marker_flag(flag:int) -> None:
     global payload_len
+    global offset
     payload_len = 0
+    global ascii_buf
+    if len(ascii_buf):      # A hack: make sure ASCII displayed from previous output; needs to have correct margin
+        print('   |'+ascii_buf+'|')
+        ascii_buf = ''
     hexstr = "%02X" % flag
     try:
         # lookup specific marker flag
-        print("\nsegment: FF %02X %s" % (flag, FLAGS[hexstr]))
+        print(f'\nMarker: {FLAGS[hexstr]} (FF{flag:02X}). Offset: {offset-1:#06X}')
     except KeyError:
         # lookup wildcarded marker flag
         hexstr = hexstr[0] + '*'
         try:
-            print("\nsegment: FF %02X %s" % (flag, FLAGS[hexstr]))
+            print(f'\nMarker: {FLAGS[hexstr]} (FF{flag:02X}). Offset: {offset-1:#06X}')
         except KeyError:
-            print("\nsegment UNKNOWN: FF %02X" % flag)
+            print(f'\nMarker: UNKNOWN: (FF{flag:02X}). Offset: {offset-1:#06X}')
+            # print("\nsegment UNKNOWN: FF %02X" % flag)
 
 payload_len = 0
 PAYLOAD_MAX = 32
+ascii_buf = ''
+
+def isprint(c):
+    return 0x20 <= c <= 0x7E
 
 def payload(data:int) -> None:
     global payload_len
     print("%02X " %data, end="")
+    global ascii_buf
+    ascii_buf += chr(data) if isprint(data) else '.'
     payload_len = (payload_len + 1) % PAYLOAD_MAX
     if payload_len == 0:
-        print()
+        print('   |'+ascii_buf+'|')         # Display ASCII output
+        ascii_buf = ''
 
 def decode(filename:str) -> None:
+    print('-'*72)
+    print(f'Filename: {filename}\nFile size: {os.stat(filename).st_size} bytes')
+    print('-'*72)
     with open(filename, "rb") as f:
         # make sure we are in sync with JPEG segment structure
 


### PR DESCRIPTION
- Display the file offset for each marker segment.
- Change the word 'segment' to 'marker'.
- Display the data content of each marker segment in ASCII as well as paired hexadecimal digits, delimited by vertical bars. -Remove superfluous newlines in the output.

Observations and TODOs
- The script correctly finds embedded markers, but doesn't indicate them as such. This means multiple occurrences of SOI can look as if it is a bug, when it isn't.
- An object oriented implementation may be better (as mentioned by DJW).
- ASCII to line up in right margin.